### PR TITLE
Remove authentication and enable direct admin access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,15 +61,16 @@ const App = () => {
               <Route path="/terms-conditions" element={<TermsConditions />} />
               <Route path="/privacy-policy" element={<PrivacyPolicy />} />
 
-              <Route path="/login" element={<Login />} />
-              <Route path="/signup" element={<Signup />} />
-              <Route element={<ProtectedRoute />}>
-                <Route path="/admin" element={<BuilderAdminIndex />} />
-                <Route path="/admin/traditional" element={<AdminIndex />} />
-                <Route path="/admin/content/:slug" element={<ContentEditor />} />
-                <Route path="/admin/:slug" element={<ContentEditor />} />
-                <Route path="/AdminIndex" element={<BuilderAdminIndex />} />
-              </Route>
+              {/* Login/Signup routes - deactivated for direct dashboard access */}
+              {/* <Route path="/login" element={<Login />} /> */}
+              {/* <Route path="/signup" element={<Signup />} /> */}
+
+              {/* Admin routes - now accessible without authentication */}
+              <Route path="/admin" element={<BuilderAdminIndex />} />
+              <Route path="/admin/traditional" element={<AdminIndex />} />
+              <Route path="/admin/content/:slug" element={<ContentEditor />} />
+              <Route path="/admin/:slug" element={<ContentEditor />} />
+              <Route path="/AdminIndex" element={<BuilderAdminIndex />} />
 
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
## Purpose
Based on user requirements to deactivate login functionality and allow direct access to the dashboard without authentication. This change removes the authentication barrier for admin routes to streamline access to the Builder CMS implementation.

## Code changes
- Commented out login and signup routes (`/login`, `/signup`)
- Removed `ProtectedRoute` wrapper from admin routes
- Made all admin routes (`/admin`, `/admin/traditional`, `/admin/content/:slug`, `/admin/:slug`, `/AdminIndex`) directly accessible without authentication
- Added explanatory comments documenting the changes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/efce1bf5e0d84b3c9c54efab6b30e72f/neon-haven)

👀 [Preview Link](https://efce1bf5e0d84b3c9c54efab6b30e72f-neon-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>efce1bf5e0d84b3c9c54efab6b30e72f</projectId>-->
<!--<branchName>neon-haven</branchName>-->